### PR TITLE
ci: update to github-slug-action v1.1.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2         
-    - uses: rlespinasse/github-slug-action@master
+    - uses: rlespinasse/github-slug-action@1.1.1
     - name: Install
       run: |
         cd client 


### PR DESCRIPTION
Related to rlespinasse/github-slug-action#15